### PR TITLE
Change how we grab rendered page

### DIFF
--- a/src/Extensions/PageHealthExtension.php
+++ b/src/Extensions/PageHealthExtension.php
@@ -2,6 +2,7 @@
 
 namespace Vulcan\Seo\Extensions;
 
+use SilverStripe\CMS\Controllers\ModelAsController;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
@@ -57,9 +58,14 @@ class PageHealthExtension extends DataExtension
     public function getRenderedHtml()
     {
         if (!$this->renderedHtml) {
-            $this->renderedHtml = file_get_contents($this->getOwner()->AbsoluteLink());
+            if ($controller = ModelAsController::controller_for($this->getOwner())) {
+                $this->renderedHtml = $controller->render();
+            }
+            else if ($content = $this->getOwner()->Content) {
+                $this->renderedHtml = $content;
+            }
         }
-
+        
         return $this->renderedHtml;
     }
 


### PR DESCRIPTION
We ran into a problem where the file_get_contents in PageHealthExtension.php was choking on basic auth (for our dev sites). If we use render() instead, we can get around this.

- use ->render() instead of file_get_contents in case of basic auth
  or other security issues
- fall back to Content field