### PR TITLE
Fixed canonical url for Security  controller actions going to a 404

### DIFF
--- a/src/Seo.php
+++ b/src/Seo.php
@@ -10,6 +10,7 @@ use QuinnInteractive\Seo\Extensions\SiteConfigSettingsExtension;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\Security\Security;
 use SilverStripe\SiteConfig\SiteConfig;
 
 /**
@@ -64,6 +65,20 @@ class Seo
     }
 
     /**
+     * Gets the current action. Good for static routes like Security where the index is a 404
+     * @return string|null
+     */
+    public static function getCurrentAction()
+    {
+        $action = null;
+        if (Controller::curr() instanceof Security) {
+            $action = Controller::curr()->getAction();
+        }
+
+        return $action;
+    }
+
+    /**
      * Creates the canonical url link
      *
      * @param \Page|PageSeoExtension|Object $owner
@@ -73,7 +88,7 @@ class Seo
     public static function getCanonicalUrlLink($owner)
     {
         return [
-            sprintf('<link rel="canonical" href="%s"/>', $owner->AbsoluteLink())
+            sprintf('<link rel="canonical" href="%s"/>', $owner->AbsoluteLink(static::getCurrentAction()))
         ];
     }
 
@@ -97,7 +112,7 @@ class Seo
             : null);
         $generator->setImageDimensions($imageWidth, $imageHeight);
         $generator->setType($owner->FacebookPageType ?: 'website');
-        $generator->setUrl($owner->AbsoluteLink());
+        $generator->setUrl($owner->AbsoluteLink(static::getCurrentAction()));
 
         return $generator->process();
     }

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -7,6 +7,7 @@ use QuinnInteractive\Seo\Builders\TwitterMetaGenerator;
 use QuinnInteractive\Seo\Extensions\PageHealthExtension;
 use QuinnInteractive\Seo\Extensions\PageSeoExtension;
 use QuinnInteractive\Seo\Extensions\SiteConfigSettingsExtension;
+use SilverStripe\Control\Controller;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\FieldType\DBDatetime;


### PR DESCRIPTION
Added a method to look up current action if current controller is security.
Before the canonical url for the login page was `example.com/Security` which produced a 404 when visiting the link. This will make the canonical url `example.com/Security/login` but will keep every other page and controller the same canonical url.