### PR TITLE
REFACTOR use MetaComponents() method allowing for better extensibility

### DIFF
--- a/src/Builders/FacebookMetaGenerator.php
+++ b/src/Builders/FacebookMetaGenerator.php
@@ -105,32 +105,32 @@ class FacebookMetaGenerator
         $tags = [];
 
         if ($this->getTitle()) {
-            $tags[] = sprintf('<meta property="og:title" content="%s"/>', htmlentities($this->getTitle()));
+            $tags['og:title'] = htmlentities($this->getTitle());
         }
 
         if ($this->getDescription()) {
-            $tags[] = sprintf('<meta property="og:description" content="%s"/>', htmlentities($this->getDescription()));
+            $tags['og:description'] = htmlentities($this->getDescription());
         }
 
         if ($this->getType()) {
-            $tags[] = sprintf('<meta property="og:type" content="%s"/>', $this->getType());
+            $tags['og:type'] = $this->getType();
         }
 
         if ($this->getUrl()) {
-            $tags[] = sprintf('<meta property="og:url" content="%s"/>', $this->getUrl());
+            $tags['og:url'] = $this->getUrl();
         }
 
         if ($this->getImageUrl()) {
-            $tags[] = sprintf('<meta property="og:image" content="%s"/>', $this->getImageUrl());
+            $tags['og:image'] = $this->getImageUrl();
         }
 
         if ($this->imageWidth && $this->imageHeight) {
-            $tags[] = sprintf('<meta property="og:image:width" content="%s" />', $this->imageWidth);
-            $tags[] = sprintf('<meta property="og:image:height" content="%s" />', $this->imageHeight);
+            $tags['og:image:width'] = $this->imageWidth;
+            $tags['og:image:height'] =  $this->imageHeight;
         }
 
-        $tags[] = sprintf('<meta property="og:locale" content="%s" />', i18n::get_locale());
-        $tags[] = sprintf('<meta property="og:site_name" content="%s" />', SiteConfig::current_site_config()->Title);
+        $tags['og:locale'] = i18n::get_locale();
+        $tags['og:site_name'] = SiteConfig::current_site_config()->Title;
 
         return $tags;
     }

--- a/src/Builders/TwitterMetaGenerator.php
+++ b/src/Builders/TwitterMetaGenerator.php
@@ -93,24 +93,24 @@ class TwitterMetaGenerator
         $siteConfig = SiteConfig::current_site_config();
         $tags       = [];
 
-        $tags[] = '<meta name="twitter:card" content="summary"/>';
+        $tags['twitter:card'] = 'summary';
         if ($this->getTitle()) {
-            $tags[] = sprintf('<meta name="twitter:title" content="%s"/>', htmlentities($this->getTitle()));
+            $tags['twitter:title'] = htmlentities($this->getTitle());
         }
 
         if ($this->getDescription()) {
-            $tags[] = sprintf('<meta name="twitter:description" content="%s"/>', htmlentities($this->getDescription()));
+            $tags['twitter:description'] = htmlentities($this->getDescription());
         }
 
         if ($this->getImageUrl()) {
-            $tags[] = sprintf('<meta name="twitter:image" content="%s"/>', $this->getImageUrl());
+            $tags['twitter:image'] = $this->getImageUrl();
         }
         if ($this->getCreator()) {
-            $tags[] = sprintf('<meta name="twitter:creator" content="@%s"/>', $this->getCreator());
+            $tags['twitter:creator'] = "@{$this->getCreator()}";
         }
 
         if ($siteConfig->TwitterAccountName) {
-            $tags[] = sprintf('<meta name="twitter:site" content="@%s" />', $siteConfig->TwitterAccountName);
+            $tags['twitter:site'] = "@$siteConfig->TwitterAccountName";
         }
 
         return $tags;

--- a/src/Extensions/PageSeoExtension.php
+++ b/src/Extensions/PageSeoExtension.php
@@ -68,6 +68,35 @@ class PageSeoExtension extends DataExtension
     ];
 
     /**
+     * @param $tags
+     */
+    public function MetaComponents(&$tags)
+    {
+        $addTag = function ($tagName, $tag) use (&$tags) {
+            $tags[$tagName] = [
+                'attributes' => [
+                    'rel' => $tagName,
+                    'content' => $tag,
+                ],
+            ];
+        };
+
+        $addTag('canonical', Seo::getCanonicalUrlLink($this->getOwner()));
+
+        foreach (Seo::getFacebookMetaTags($this->getOwner()) as $tagName => $tag) {
+            $addTag($tagName, $tag);
+        }
+
+        foreach (Seo::getTwitterMetaTags($this->getOwner()) as $tagName => $tag) {
+            $addTag($tagName, $tag);
+        }
+
+        foreach (Seo::getArticleTags($this->getOwner()) as $tagName => $tag) {
+            $addTag($tagName, $tag);
+        }
+    }
+
+    /**
      * Extension point for SiteTree to merge all tags with the standard meta tags
      *
      * @param $tags
@@ -77,10 +106,6 @@ class PageSeoExtension extends DataExtension
         $tags = explode(PHP_EOL, $tags);
         $tags = array_merge(
             $tags,
-            Seo::getCanonicalUrlLink($this->getOwner()),
-            Seo::getFacebookMetaTags($this->getOwner()),
-            Seo::getTwitterMetaTags($this->getOwner()),
-            Seo::getArticleTags($this->getOwner()),
             Seo::getGoogleAnalytics(),
             Seo::getPixels()
         );

--- a/src/Seo.php
+++ b/src/Seo.php
@@ -64,8 +64,8 @@ class Seo
         $modified = $owner->dbObject('LastEdited');
 
         return [
-            sprintf('<meta property="article:published_time" content="%s" />', $published->Rfc3339()),
-            sprintf('<meta property="article:modified_time" content="%s" />', $modified->Rfc3339()),
+            'article:published_time' => $published->Rfc3339(),
+            'article:modified_time' => $modified->Rfc3339(),
         ];
     }
 
@@ -92,9 +92,7 @@ class Seo
      */
     public static function getCanonicalUrlLink($owner)
     {
-        return [
-            sprintf('<link rel="canonical" href="%s"/>', $owner->AbsoluteLink(static::getCurrentAction()))
-        ];
+        return $owner->AbsoluteLink(static::getCurrentAction());
     }
 
     /**

--- a/tests/Extensions/PageSeoExtensionTest.php
+++ b/tests/Extensions/PageSeoExtensionTest.php
@@ -31,7 +31,7 @@ class PageSeoExtensionTest extends FunctionalTest
 
     public function testCanonicalLink()
     {
-        $this->assertContains(Director::absoluteBaseURL(), Seo::getCanonicalUrlLink($this->page)[0]);
+        $this->assertContains(Director::absoluteBaseURL(), Seo::getCanonicalUrlLink($this->page));
     }
 
     public function testArticleTags()
@@ -44,22 +44,32 @@ class PageSeoExtensionTest extends FunctionalTest
 
         $this->assertContains(
             $created->Rfc3339(),
-            Seo::getArticleTags($this->page)[0]
+            Seo::getArticleTags($this->page)
         );
         $this->assertContains(
             $lastEdited->Rfc3339(),
-            Seo::getArticleTags($this->page)[1]
+            Seo::getArticleTags($this->page)
         );
     }
 
-    public function testMetaTags()
+    public function testMetaComponents()
     {
-        $tags = $this->page->MetaTags(false);
+        $tags = $this->page->MetaComponents();
 
-        $this->assertContains(Seo::getCanonicalUrlLink($this->page)[0], $tags);
-        $this->assertContains(Seo::getArticleTags($this->page)[0], $tags);
-        $this->assertContains(Seo::getArticleTags($this->page)[1], $tags);
-        $this->assertContains(implode(PHP_EOL, Seo::getFacebookMetaTags($this->page)), $tags);
-        $this->assertContains(implode(PHP_EOL, Seo::getTwitterMetaTags($this->page)), $tags);
+        $this->assertContains(Seo::getCanonicalUrlLink($this->page), $tags['canonical']['attributes']);
+
+        $this->assertContains(Seo::getArticleTags($this->page)['article:published_time'], $tags['article:published_time']['attributes']);
+        $this->assertContains(Seo::getArticleTags($this->page)['article:modified_time'], $tags['article:modified_time']['attributes']);
+
+        $this->assertContains(Seo::getFacebookMetaTags($this->page)['og:title'], $tags['og:title']['attributes']);
+        $this->assertContains(Seo::getFacebookMetaTags($this->page)['og:description'], $tags['og:description']['attributes']);
+        $this->assertContains(Seo::getFacebookMetaTags($this->page)['og:type'], $tags['og:type']['attributes']);
+        $this->assertContains(Seo::getFacebookMetaTags($this->page)['og:url'], $tags['og:url']['attributes']);
+        $this->assertContains(Seo::getFacebookMetaTags($this->page)['og:locale'], $tags['og:locale']['attributes']);
+        $this->assertContains(Seo::getFacebookMetaTags($this->page)['og:site_name'], $tags['og:site_name']['attributes']);
+
+        $this->assertContains(Seo::getTwitterMetaTags($this->page)['twitter:card'], $tags['twitter:card']['attributes']);
+        $this->assertContains(Seo::getTwitterMetaTags($this->page)['twitter:title'], $tags['twitter:title']['attributes']);
+        $this->assertContains(Seo::getTwitterMetaTags($this->page)['twitter:description'], $tags['twitter:description']['attributes']);
     }
 }


### PR DESCRIPTION
resolves #59

This is a fairly major change to how the tags are built. I've updated the existing tests to match using the `MetaComponents()` method and things appear to be generating as expected.

One thing I did not take into account with this update is if there is a desire for additional logic surrounding the handling of the canonical tag for things like Virtual Page, or if a canonical already exists from some other extension. If this module's extension is loaded last, it will simply overwrite any canonical in the MetaComponents. That being said, any module using the `MetaTags()` method, and setting a canonical could result in two canonical tags being generated.

Open to feedback on any/all of this and am happy to update where needed.