### PR TITLE
fix: check for null before using str operations

### DIFF
--- a/src/Analysis/FocusKeywordContentAnalysis.php
+++ b/src/Analysis/FocusKeywordContentAnalysis.php
@@ -39,12 +39,12 @@ class FocusKeywordContentAnalysis extends Analysis
     public function getContentFromDom()
     {
         $dom    = $this->getPage()->getRenderedHtmlDomParser();
-        
+
         if (!$dom) {
            return '';
         }
 
-        
+
         $result = $dom->find('body', 0);
 
         return strtolower(strip_tags($result ? $result->innertext() : ''));
@@ -55,7 +55,11 @@ class FocusKeywordContentAnalysis extends Analysis
      */
     public function getKeyword()
     {
-        return strtolower($this->getPage()->FocusKeyword);
+        if ($keyword = $this->getPage()->FocusKeyword) {
+            return strtolower($keyword);
+        }
+
+        return '';
     }
 
     /**

--- a/src/Analysis/FocusKeywordUniqueAnalysis.php
+++ b/src/Analysis/FocusKeywordUniqueAnalysis.php
@@ -17,7 +17,11 @@ class FocusKeywordUniqueAnalysis extends Analysis
      */
     public function getKeyword()
     {
-        return strtolower($this->getPage()->FocusKeyword);
+        if ($keyword = $this->getPage()->FocusKeyword) {
+            return strtolower($keyword);
+        }
+
+        return '';
     }
 
     /**

--- a/src/Analysis/FocusKeywordUrlAnalysis.php
+++ b/src/Analysis/FocusKeywordUrlAnalysis.php
@@ -24,7 +24,11 @@ class FocusKeywordUrlAnalysis extends Analysis
      */
     public function getKeyword()
     {
-        return strtolower($this->getPage()->FocusKeyword);
+        if ($keyword = $this->getPage()->FocusKeyword) {
+            return strtolower($keyword);
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
When using PHP 8.1 with deprecated warnings enabled this prevents the [Deprecated] strtolower(): Passing null to parameter #1 ($string) of type string is deprecated notice.